### PR TITLE
fix(Select): forward ref to enhanced menu

### DIFF
--- a/src/select/select/index.tsx
+++ b/src/select/select/index.tsx
@@ -48,7 +48,7 @@ export interface SelectProps {
   /** Makes the Select required.  */
   required?: boolean;
   /** Renders a non native / enhanced dropdown */
-  enhanced?: boolean | MenuProps;
+  enhanced?: boolean | (MenuProps & { ref?: React.Ref<HTMLElement> });
   /** Props for the root element. By default, additional props spread to the native select element.  */
   rootProps?: Object;
   /** A reference to the native select element. Not applicable when `enhanced` is true. */
@@ -190,7 +190,7 @@ interface EnhancedMenuProps extends MenuProps {
   children?: React.ReactNode;
 }
 
-function EnhancedMenu(props: EnhancedMenuProps & SelectHTMLProps) {
+const EnhancedMenu = React.forwardRef((props: EnhancedMenuProps & SelectHTMLProps, ref: React.Ref<HTMLElement>) => {
   const {
     selectOptions,
     menuApiRef,
@@ -231,6 +231,7 @@ function EnhancedMenu(props: EnhancedMenuProps & SelectHTMLProps) {
   return (
     <Menu
       {...rest}
+      ref={ref}
       apiRef={menuApiRef}
       className="mdc-select__menu"
       focusOnOpen


### PR DESCRIPTION
Properly forwards the `ref` property to the underlying `Menu` component if passed in the `enhanced` prop to a `Select`.