### PR TITLE
fix(textfield): Add back styling for date picker

### DIFF
--- a/src/textfield/styles.tsx
+++ b/src/textfield/styles.tsx
@@ -4,3 +4,4 @@ import '@rmwc/notched-outline/styles';
 import '@rmwc/line-ripple/styles';
 import '@rmwc/ripple/styles';
 import '@rmwc/icon/styles';
+import '@rmwc/textfield/textfield.css';

--- a/src/textfield/textfield.css
+++ b/src/textfield/textfield.css
@@ -1,0 +1,3 @@
+.mdc-text-field__input::-webkit-calendar-picker-indicator {
+  display: initial;
+}


### PR DESCRIPTION
Fixes an issue of date-picker not showing up with type="date". A result of this commit on material-components-web: https://github.com/material-components/material-components-web/commit/4951e7651ffbd99b382948e48306a23d2fd74fb1