### PR TITLE
fix(type): Extends {} to fix error in declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "rmwc-main",
 	"author": "James Friedman",
-	"version": "8.0.1",
+	"version": "8.0.2",
 	"private": true,
 	"homepage": "https://rmwc.io",
 	"description": "RMWC is a React UI Kit built on Google's official Material Components Web library.",

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -122,8 +122,8 @@ export type ComponentProps<
   );
 
 export type ComponentType<
-  Props,
-  ElementProps,
+  Props extends {},
+  ElementProps extends {},
   Element extends React.ElementType<any>
 > = {
   <Tag extends React.ElementType<any> = Element>(


### PR DESCRIPTION
Fixes issue when depending on RMWC 8.x. which says:
```
<Tag extends React.ElementType<any> = Element>(props: ComponentProps<Props, ElementsProps, Tag>, ref: any): JSX.Element;

Type 'Props' does not satisfy the constraint '{}'
```