### PR TITLE
feat(portal): Support Portal in a ShadowDom by using PortalContext

### DIFF
--- a/scripts/docgen-examples.js
+++ b/scripts/docgen-examples.js
@@ -2,12 +2,12 @@ const path = require('path');
 const fs = require('fs');
 const getAllPackages = require('./get-all-packages');
 
-const genDocExample = packageName => {
+const genDocExample = (packageName) => {
   const readmeFiles = fs
     .readdirSync(path.resolve('src', packageName))
-    .filter(fName => fName.startsWith('readme') && fName.endsWith('.tsx'));
+    .filter((fName) => fName.startsWith('readme') && fName.endsWith('.tsx'));
 
-  readmeFiles.forEach(fName => {
+  readmeFiles.forEach((fName) => {
     const docsExamplePath = path.resolve('src', packageName, fName);
     const examplesFilename =
       fName === 'readme.tsx'
@@ -25,7 +25,7 @@ const genDocExample = packageName => {
         match && matches.push(match[1]);
       }
 
-      const formattedMatches = matches.map(m => {
+      const formattedMatches = matches.map((m) => {
         // do some global find and replace
         m = m.replace(/\<any\>/g, '');
         m = m.replace(/\/\* jsx \*\/ /g, '');
@@ -33,10 +33,10 @@ const genDocExample = packageName => {
         const parts = m
           .split('\n')
           .slice(1, -1)
-          .filter(l => !l.includes('@ts-ignore'));
+          .filter((l) => !l.includes('@ts-ignore'));
         const regexp = /(^\s+)/g;
         const trimLength = regexp.exec(parts[0])[1].length;
-        let cleaned = parts.map(p => p.slice(trimLength)).join('\n');
+        let cleaned = parts.map((p) => p.slice(trimLength)).join('\n');
         if (cleaned.startsWith('{')) {
           cleaned = cleaned.slice(1, -1);
         }
@@ -57,8 +57,8 @@ const genDocExample = packageName => {
 
 try {
   getAllPackages()
-    .filter(name => !['base', 'rmwc', '@types'].includes(name))
-    .forEach(d => {
+    .filter((name) => !['rmwc', '@types'].includes(name))
+    .forEach((d) => {
       console.log(`Generating Examples For: ${d}`);
       genDocExample(d);
     });

--- a/scripts/docgen-markdown.js
+++ b/scripts/docgen-markdown.js
@@ -10,12 +10,12 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const getChangedPackages = require('./get-changed-packages');
 
-const getMarkdown = packageName => {
+const getMarkdown = (packageName) => {
   const readmeFiles = fs
     .readdirSync(path.resolve('build', 'dist', packageName))
-    .filter(fName => fName.startsWith('readme') && fName.endsWith('.js'));
+    .filter((fName) => fName.startsWith('readme') && fName.endsWith('.js'));
 
-  const promises = readmeFiles.map(fName => {
+  const promises = readmeFiles.map((fName) => {
     const docPath = path.resolve('build', 'dist', packageName, fName);
     const fileOutputName = path.basename(fName, '.js').toUpperCase() + '.md';
     const outputPath = path.resolve('src', packageName, fileOutputName);
@@ -26,7 +26,7 @@ const getMarkdown = packageName => {
       .replace(/&#x27;/g, "'")
       .replace(/&quot;/g, '"');
 
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       fs.writeFile(outputPath, content, () => {
         resolve();
       });
@@ -47,8 +47,8 @@ try {
   execSync(`./node_modules/.bin/copyfiles --up 1 src/**/*.json build/dist`);
 
   const promises = getChangedPackages()
-    .filter(name => !['base', 'rmwc', '@types'].includes(name))
-    .map(d => {
+    .filter((name) => !['rmwc', '@types'].includes(name))
+    .map((d) => {
       console.log(`Generating Markdown For: ${d}`);
       return getMarkdown(d);
     });

--- a/scripts/docgen-props.js
+++ b/scripts/docgen-props.js
@@ -8,7 +8,7 @@ const getPackages =
 
 try {
   getPackages()
-    .filter((name) => !['base', 'rmwc', '@types'].includes(name))
+    .filter((name) => !['rmwc', '@types'].includes(name))
     .forEach((d) => {
       console.log(`Building Docs For: ${d}`);
       const proc = exec(

--- a/src/base/PortalContext.tsx
+++ b/src/base/PortalContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, ReactNode, useState } from 'react';
+import React, { createContext, ReactNode, useState } from 'react';
 
 export interface PortalContextData {
   portalElement: HTMLDivElement | null;
@@ -14,7 +14,7 @@ export const PortalContext = createContext<PortalContextData>(
   portalContextDefaultValues
 );
 
-export const PortalProvider: FC<ReactNode> = ({ children }) => {
+export const PortalProvider: React.FC<ReactNode> = ({ children }) => {
   const [element, setElement] = useState<HTMLDivElement | null>(null);
 
   return (

--- a/src/base/PortalContext.tsx
+++ b/src/base/PortalContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, FC, ReactNode, useState } from 'react';
+
+export interface PortalContextData {
+  portalElement: HTMLDivElement | null;
+  setPortalElement: ((element: HTMLDivElement) => void) | null;
+}
+
+export const portalContextDefaultValues = {
+  portalElement: null,
+  setPortalElement: null
+};
+
+export const PortalContext = createContext<PortalContextData>(
+  portalContextDefaultValues
+);
+
+export const PortalProvider: FC<ReactNode> = ({ children }) => {
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+
+  return (
+    <PortalContext.Provider
+      value={{
+        portalElement: element,
+        setPortalElement: setElement
+      }}
+    >
+      {children}
+    </PortalContext.Provider>
+  );
+};

--- a/src/base/README.md
+++ b/src/base/README.md
@@ -1,3 +1,33 @@
-# RMWC Base module
+# Portal
 
-This module contains core functionality shared between all RMWC components.
+The Portal component will let you render components to a portal.
+
+- Module **@rmwc/base**
+
+
+## Portal
+
+```jsx
+
+```
+
+## PortalProvider
+
+The PortalProvider component is an optional component that provides a global context for the Portal element in the RMWC library. This context is used by the Portal component to retrieve the Portal element without relying on document.getElementById, which doesn't work inside a Shadow DOM.
+
+The PortalProvider component is used by importing it into your project and wrapping it around your application or component tree similar to TypographyProvider.
+
+```jsx
+
+```
+
+In this example, the PortalProvider component is used to wrap the Portal component. Elements rendered to the portal will now render directly to the portalElement stored in the portal context instead of retrieving the Portal element using document.getElementById(). The PortalProvider component is optional for most users. If you are using the RMWC library in a Shadow DOM and the Portal component is not rendering inside the correct Portal element, then you can use the PortalProvider component to ensure that the Portal element is retrieved using the PortalContext.
+
+## Notes
+
+The PortalProvider component does not accept any props.
+
+The Portal component only needs to be a descendent of PortalProvider for it to be functional.
+
+Unlike ThemeProvider or TypographyProvider, the PortalProvider component should only be used once in your application or component tree. (If you include multiple instances of PortalProvider, the context will only grab the context values from the first PortalProvider parent and the solution will break.)
+

--- a/src/base/generated-examples.json
+++ b/src/base/generated-examples.json
@@ -1,0 +1,1 @@
+["<Portal />","function App() {\n  return (\n    <PortalProvider>\n      <div>\n        {/* Other components here */}\n        <Portal />\n      </div>\n    </PortalProvider>\n  );\n}"]

--- a/src/base/index.spec.tsx
+++ b/src/base/index.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import {
   withTheme,
@@ -237,6 +237,7 @@ describe('Portal', () => {
     const { asFragment } = render(<Portal />);
     expect(asFragment()).toMatchSnapshot();
   });
+
   it('does not mount twice', async () => {
     const Content = ({ value, inc }: { value: number; inc: () => void }) => {
       React.useEffect(() => {
@@ -262,11 +263,146 @@ describe('Portal', () => {
           )
         </>
       );
-      
     };
     render(<MyComp />);
     userEvent.click(screen.getByRole('button', { name: /open/i }));
     expect(await screen.findByText('Opened 1 times')).toBeInTheDocument();
+  });
+
+  it('renders to portal when using PortalProvider and renderToPortal is true', () => {
+    const MyComp = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <PortalProvider>
+          <div data-testid="portal-sibling">
+            <Button data-testid="trigger-button" onClick={() => setOpen(true)}>
+              Open
+            </Button>
+            <Dialog
+              renderToPortal={true}
+              open={open}
+              onClosed={() => setOpen(false)}
+            >
+              <DialogContent>
+                <Button data-testid="dialog-content-button" />
+              </DialogContent>
+            </Dialog>
+          </div>
+          <Portal data-testid="rmwc-portal" />
+        </PortalProvider>
+      );
+    };
+
+    render(<MyComp />);
+    const portalSibling = screen.getByTestId('portal-sibling');
+    const portalElement = screen.getByTestId('rmwc-portal');
+    const dialogContentButton = screen.getByTestId('dialog-content-button');
+
+    expect(portalSibling).not.toContainElement(dialogContentButton);
+    expect(portalElement).toContainElement(dialogContentButton);
+  });
+
+  it('does not render to portal when using PortalProvider and renderToPortal is false', () => {
+    const MyComp = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <PortalProvider>
+          <div data-testid="portal-sibling">
+            <Button data-testid="trigger-button" onClick={() => setOpen(true)}>
+              Open
+            </Button>
+            <Dialog
+              renderToPortal={false}
+              open={open}
+              onClosed={() => setOpen(false)}
+            >
+              <DialogContent>
+                <Button data-testid="dialog-content-button" />
+              </DialogContent>
+            </Dialog>
+          </div>
+          <Portal data-testid="rmwc-portal" />
+        </PortalProvider>
+      );
+    };
+
+    render(<MyComp />);
+    const portalSibling = screen.getByTestId('portal-sibling');
+    const portalElement = screen.getByTestId('rmwc-portal');
+    const dialogContentButton = screen.getByTestId('dialog-content-button');
+
+    expect(portalSibling).toContainElement(dialogContentButton);
+    expect(portalElement).not.toContainElement(dialogContentButton);
+  });
+
+  it('renders to portal when not using PortalProvider and renderToPortal is true', () => {
+    const MyComp = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <>
+          <div data-testid="portal-sibling">
+            <Button data-testid="trigger-button" onClick={() => setOpen(true)}>
+              Open
+            </Button>
+            <Dialog
+              renderToPortal={true}
+              open={open}
+              onClosed={() => setOpen(false)}
+            >
+              <DialogContent>
+                <Button data-testid="dialog-content-button" />
+              </DialogContent>
+            </Dialog>
+          </div>
+          <Portal data-testid="rmwc-portal" />
+        </>
+      );
+    };
+
+    render(<MyComp />);
+    const portalSibling = screen.getByTestId('portal-sibling');
+    const portalElement = screen.getByTestId('rmwc-portal');
+    const dialogContentButton = screen.getByTestId('dialog-content-button');
+
+    expect(portalSibling).not.toContainElement(dialogContentButton);
+    expect(portalElement).toContainElement(dialogContentButton);
+  });
+
+  it('does not render to portal when not using PortalProvider and renderToPortal is false', () => {
+    const MyComp = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <>
+          <div data-testid="portal-sibling">
+            <Button data-testid="trigger-button" onClick={() => setOpen(true)}>
+              Open
+            </Button>
+            <Dialog
+              renderToPortal={false}
+              open={open}
+              onClosed={() => setOpen(false)}
+            >
+              <DialogContent>
+                <Button data-testid="dialog-content-button" />
+              </DialogContent>
+            </Dialog>
+          </div>
+          <Portal data-testid="rmwc-portal" />
+        </>
+      );
+    };
+
+    render(<MyComp />);
+    const portalSibling = screen.getByTestId('portal-sibling');
+    const portalElement = screen.getByTestId('rmwc-portal');
+    const dialogContentButton = screen.getByTestId('dialog-content-button');
+
+    expect(portalSibling).toContainElement(dialogContentButton);
+    expect(portalElement).not.toContainElement(dialogContentButton);
   });
 });
 

--- a/src/base/index.tsx
+++ b/src/base/index.tsx
@@ -7,5 +7,6 @@ export * from './utils';
 export * from './foundation-component';
 export * from './component';
 export * from './portal';
+export * from './PortalContext';
 
 export type WithThemeProps = _WithThemeProps;

--- a/src/base/portal.tsx
+++ b/src/base/portal.tsx
@@ -6,13 +6,17 @@ import React, {
   MutableRefObject
 } from 'react';
 import { createPortal } from 'react-dom';
+import * as RMWC from '@rmwc/types';
 import { PortalContext } from './PortalContext';
 
 const PORTAL_ID = 'rmwcPortal';
 
 export type PortalPropT = Element | string | boolean | undefined | null;
 
-export const Portal = (): JSX.Element => {
+export interface PortalProps
+  extends Omit<RMWC.HTMLProps<HTMLDivElement>, 'id' | 'ref'> {}
+
+export const Portal = (props: PortalProps): JSX.Element => {
   const portalContext = useContext(PortalContext);
   const setPortalElement = portalContext?.setPortalElement;
 
@@ -25,7 +29,7 @@ export const Portal = (): JSX.Element => {
     [setPortalElement]
   );
 
-  return <div ref={portalRef} id={PORTAL_ID} />;
+  return <div ref={portalRef} id={PORTAL_ID} {...props} />;
 };
 
 export function PortalChild({

--- a/src/base/portal.tsx
+++ b/src/base/portal.tsx
@@ -1,9 +1,8 @@
-import {
+import React, {
   useEffect,
   useState,
   useContext,
   useCallback,
-  ReactNode,
   MutableRefObject
 } from 'react';
 import { createPortal } from 'react-dom';
@@ -34,7 +33,7 @@ export function PortalChild({
   renderTo,
   menuSurfaceDomPositionRef
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   renderTo?: PortalPropT;
   menuSurfaceDomPositionRef?: MutableRefObject<HTMLDivElement | null>;
 }) {

--- a/src/base/readme.tsx
+++ b/src/base/readme.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import { Docs, DocsExample, DocsP, DocsSubtitle } from '@doc-utils';
+import examples from './generated-examples.json';
+
+import { Portal, PortalProvider } from '.';
+
+export default function Readme() {
+  return (
+    <Docs
+      title="Portal"
+      lead="The Portal component will let you render components to a portal."
+      module="@rmwc/base"
+      styles={[]}
+      examples={examples}
+    >
+      <DocsSubtitle>Portal</DocsSubtitle>
+      <DocsExample label="Default">
+        <Portal />
+      </DocsExample>
+
+      <DocsSubtitle>PortalProvider (optional)</DocsSubtitle>
+      <DocsP>
+        The PortalProvider component is an optional component that provides a
+        global context for the Portal element in the RMWC library. This context
+        is used by the Portal component to retrieve the Portal element without
+        relying on document.getElementById, which doesn't work inside a Shadow
+        DOM.
+      </DocsP>
+
+      <DocsP>
+        The PortalProvider component is used by importing it into your project
+        and wrapping it around your application or component tree similar to
+        TypographyProvider.
+      </DocsP>
+
+      <DocsExample label="Default">
+        {function App() {
+          return (
+            <PortalProvider>
+              <div>
+                {/* Other components here */}
+                <Portal />
+              </div>
+            </PortalProvider>
+          );
+        }}
+      </DocsExample>
+
+      <DocsP>
+        In this example, the PortalProvider component is used to wrap the Portal
+        component. Elements rendered to the portal will now render directly to
+        the portalElement stored in the portal context instead of retrieving the
+        Portal element using `document.getElementById()`.
+      </DocsP>
+      <DocsP>
+        The PortalProvider component is optional for most users. If you are
+        using the RMWC library in a Shadow DOM and the Portal component is not
+        rendering inside the correct Portal element, then you can use the
+        PortalProvider component to ensure that the Portal element is retrieved
+        using the PortalContext.
+      </DocsP>
+
+      <DocsSubtitle>Notes</DocsSubtitle>
+      <DocsP>The PortalProvider component does not accept any props.</DocsP>
+      <DocsP>
+        The Portal component only needs to be a descendent of PortalProvider for
+        it to be functional.
+      </DocsP>
+      <DocsP>
+        Unlike ThemeProvider or TypographyProvider, the PortalProvider component
+        should only be used once in your application or component tree. (If you
+        include multiple instances of PortalProvider, the context will only grab
+        the context values from the first PortalProvider parent and the solution
+        will break.)
+      </DocsP>
+
+      {/* <DocProps
+        src={propsSrc}
+        components={[{ displayName: 'Button', component: Button }]}
+      /> */}
+    </Docs>
+  );
+}

--- a/src/rmwc/docs/common/menu-content.tsx
+++ b/src/rmwc/docs/common/menu-content.tsx
@@ -95,6 +95,7 @@ const TypographyDocs = React.lazy(() => import('@rmwc/typography/readme'));
 const IconDocs = React.lazy(() => import('@rmwc/icon/readme'));
 const ProviderDocs = React.lazy(() => import('@rmwc/provider/readme'));
 const TooltipDocs = React.lazy(() => import('@rmwc/tooltip/readme'));
+const PortalDocs = React.lazy(() => import('@rmwc/base/readme'));
 
 const Loading = () => (
   <div
@@ -410,6 +411,11 @@ export const menuContent: MenuItemT[] = [
         label: 'Provider',
         url: `/provider`,
         component: Loadable(ProviderDocs)
+      },
+      {
+        label: 'Portal',
+        url: `/portal`,
+        component: Loadable(PortalDocs)
       }
     ]
   }

--- a/src/rmwc/docs/views/app/index.tsx
+++ b/src/rmwc/docs/views/app/index.tsx
@@ -35,6 +35,7 @@ import { SiteSearch } from '../site-search';
 import { DOC_VERSIONS } from '../../common/doc-versions';
 import { menuContent, MenuItemT } from '../../common/menu-content';
 import { ThemePicker, getTheme } from './theme-picker';
+import { PortalProvider } from '@rmwc/base/PortalContext';
 
 const MainMenuItem = ({ url, label }: { url?: string; label: string }) => {
   const location = useLocation();
@@ -175,38 +176,40 @@ export function App() {
       tag="div"
       id={pageId}
     >
-      <AppBar
-        onNavClick={(evt) => {
-          setMenuIsOpen(!menuIsOpen);
-        }}
-      >
-        {!isMobile && (
-          <ThemePicker
-            selectedThemeName={theme}
-            onThemeClick={(themeName) => {
-              window.localStorage.setItem('rmwcTheme', themeName);
-              setTheme(themeName);
-            }}
+      <PortalProvider>
+        <AppBar
+          onNavClick={(evt) => {
+            setMenuIsOpen(!menuIsOpen);
+          }}
+        >
+          {!isMobile && (
+            <ThemePicker
+              selectedThemeName={theme}
+              onThemeClick={(themeName) => {
+                window.localStorage.setItem('rmwcTheme', themeName);
+                setTheme(themeName);
+              }}
+            />
+          )}
+        </AppBar>
+
+        <div className="demo-content">
+          <Nav
+            open={menuIsOpen}
+            dismissible={!isMobile}
+            modal={isMobile}
+            onClose={() => setMenuIsOpen(false)}
           />
-        )}
-      </AppBar>
 
-      <div className="demo-content">
-        <Nav
-          open={menuIsOpen}
-          dismissible={!isMobile}
-          modal={isMobile}
-          onClose={() => setMenuIsOpen(false)}
-        />
-
-        <DrawerAppContent tag="main" className="app__content">
-          <Routes>
-            <Route key={'home'} path="/" element={<Home />} />
-            {getDocRoutes({ options: menuContent })}
-          </Routes>
-        </DrawerAppContent>
-      </div>
-      <Portal />
+          <DrawerAppContent tag="main" className="app__content">
+            <Routes>
+              <Route key={'home'} path="/" element={<Home />} />
+              {getDocRoutes({ options: menuContent })}
+            </Routes>
+          </DrawerAppContent>
+        </div>
+        <Portal />
+      </PortalProvider>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
This PR is intended to solve #853.

Solution:

- Created a PortalContext to store the portal element and function to set element
- If PortalContext is not found, the Portal should work exactly the same as before
- Portal element will set `portalElement` in PortalProvider if PortalContext is found
- PortalChild will render to the `portalElementFromContext` if found and `renderTo` is `true`
- I added `PortalProvider` to `App` to demonstrate its capability
- I didn't add any tests, but all tests are still passing

Notes:
I believe this is my first PR for RMWC so I'm not expecting this to be approved, but am hoping it will be enough for the team to determine if this is an acceptable solution.

Since I was modifying an existing component, I didn't know if any other files were necessary. Please advise and I will update.