### PR TITLE
fix: publish step should change dependency versions

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -47,6 +47,11 @@
         "{workspaceRoot}/.eslintignore",
         "{workspaceRoot}/eslint.config.js"
       ]
+    },
+    "npm-deploy": {
+      "options": {
+        "noBuild": true
+      }
     }
   },
   "namedInputs": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "prerelease:minor": "nx version workspace --releaseAs=preminor --preid=alpha",
     "prerelease:major": "nx version workspace --releaseAs=premajor --preid=alpha",
     "prerelease:alpha": "nx version workspace --releaseAs=prerelease --preid=alpha",
-    "publish:packages": "nx run-many -t npm-deploy",
+    "publish:packages": "nx run-many -t build --projects=tag:publishable && node ./scripts/fix-dependency-versions.js && nx run-many -t npm-deploy --projects=tag:publishable",
     "publish:docs": "npm run build:docs && git add docs -f && git commit --allow-empty -m 'Deploying docs' && git push --force",
     "changelog": "changelog || echo 'No Changes'",
     "prepare": "husky install",

--- a/scripts/fix-dependency-versions.js
+++ b/scripts/fix-dependency-versions.js
@@ -12,6 +12,8 @@ const root = path.resolve(__dirname, '../');
 const rootPackagePath = path.resolve(root, 'package.json');
 const rootPackageJson = JSON.parse(fs.readFileSync(rootPackagePath, 'utf8'));
 
+let logVerbose = process.argv.includes('--verbose');
+
 // Read all package.json files in dist/packages
 const packagesPath = path.resolve(root, 'dist/packages');
 const packages = fs.readdirSync(packagesPath);
@@ -24,10 +26,9 @@ packages.forEach((packageName) => {
   }
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-  if (packageName !== 'base') {
-    return;
+  if (logVerbose) {
+    console.log(`Updating ${packageName}...`);
   }
-  console.log(`Updating ${packageName}...`);
   updateDependencies(packageJson.dependencies);
   updateDependencies(packageJson.devDependencies);
   updateDependencies(packageJson.peerDependencies);
@@ -37,8 +38,12 @@ packages.forEach((packageName) => {
     JSON.stringify(packageJson, null, 2),
     'utf8'
   );
-  console.log(`Updated ${packageName}!`);
+  if (logVerbose) {
+    console.log(`Updated ${packageName}!`);
+  }
 });
+
+console.log('Fixed dependency versions!');
 
 function updateDependencies(dependencies) {
   if (!dependencies) {


### PR DESCRIPTION
This ensures that the built packages have their dependency versions corrected from `workspace:*` to the current version