### PR TITLE
fix(tooltip): use correct unique id

### DIFF
--- a/packages/tooltip/src/lib/__snapshots__/tooltip.spec.tsx.snap
+++ b/packages/tooltip/src/lib/__snapshots__/tooltip.spec.tsx.snap
@@ -6,16 +6,16 @@ exports[`Tooltip > can be rich 1`] = `
     class="mdc-tooltip-wrapper--rich"
   >
     <span
-      aria-describedby="123456"
+      aria-describedby="tooltip-test"
       class=""
-      data-tooltip-id="123456"
+      data-tooltip-id="tooltip-test"
     >
       test
     </span>
     <div
       aria-hidden="false"
       class="mdc-tooltip mdc-tooltip--rich"
-      id="123456"
+      id="tooltip-test"
       role="dialog"
     >
       <div
@@ -36,9 +36,9 @@ exports[`Tooltip > can be rich and persistent 1`] = `
     class="mdc-tooltip-wrapper--rich"
   >
     <span
-      aria-describedby="123456"
+      aria-describedby="tooltip-test"
       class=""
-      data-tooltip-id="123456"
+      data-tooltip-id="tooltip-test"
     >
       test
     </span>
@@ -46,7 +46,7 @@ exports[`Tooltip > can be rich and persistent 1`] = `
       aria-hidden="false"
       class="mdc-tooltip mdc-tooltip--rich"
       data-mdc-tooltip-persistent="true"
-      id="123456"
+      id="tooltip-test"
       role="dialog"
       tabindex="-1"
     >
@@ -68,16 +68,16 @@ exports[`Tooltip > can be rich with default rich styling disabled 1`] = `
     class="mdc-tooltip-wrapper--rich"
   >
     <span
-      aria-describedby="123456"
+      aria-describedby="tooltip-test"
       class=""
-      data-tooltip-id="123456"
+      data-tooltip-id="tooltip-test"
     >
       test
     </span>
     <div
       aria-hidden="false"
       class="mdc-tooltip rmwc-tooltip"
-      id="123456"
+      id="tooltip-test"
       role="dialog"
     >
       <div
@@ -98,7 +98,7 @@ exports[`Tooltip > renders 1`] = `
     aria-hidden="true"
     class="mdc-tooltip mdc-tooltip--showing"
     data-mdc-tooltip-persistent="true"
-    id="123456"
+    id="tooltip-test"
     role="tooltip"
     style="top: 4px; left: 0px;"
   >
@@ -110,9 +110,9 @@ exports[`Tooltip > renders 1`] = `
     </div>
   </div>
   <span
-    aria-describedby="123456"
+    aria-describedby="tooltip-test"
     class=""
-    data-tooltip-id="123456"
+    data-tooltip-id="tooltip-test"
     element="[object Object]"
   >
     test

--- a/packages/tooltip/src/lib/tooltip.tsx
+++ b/packages/tooltip/src/lib/tooltip.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as RMWC from '@rmwc/types';
-import { classNames, createComponent, Tag } from '@rmwc/base';
+import { classNames, createComponent, Tag, useId } from '@rmwc/base';
 import { useProviderContext } from '@rmwc/provider';
 import { useToolTipFoundation } from './foundation';
 import { AnchorBoundaryType } from '@material/tooltip';
@@ -62,7 +62,7 @@ export const Tooltip: RMWC.ComponentType<
     ...props
   };
 
-  const uniqueId = crypto.randomUUID();
+  const uniqueId = useId('tooltip', props);
 
   const isRich = typeof overlay !== 'string';
 

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -3,12 +3,6 @@ import '@testing-library/jest-dom';
 import { beforeAll, vi } from 'vitest';
 import rmwcTestPolyfill from './packages/base/src/lib/test-polyfill';
 
-Object.defineProperty(global, 'crypto', {
-  value: {
-    randomUUID: () => 123456
-  }
-});
-
 rmwcTestPolyfill();
 
 const consoleError = console.error;


### PR DESCRIPTION
Using crypto to generate id was not a good solution as it would generate a random id on every render. Not great for snapshot testing as well.... luckily James has been smart as always, and already created a proper `useId` hook! So I used that instead. Cheers.