### PR TITLE
chore: remove sideEffects from package.json

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -17,9 +17,6 @@
     },
     "./avatar.css": "./avatar.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -16,9 +16,6 @@
     },
     "./badge.css": "./badge.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -17,9 +17,6 @@
     },
     "./chip.css": "./chip.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/circular-progress/package.json
+++ b/packages/circular-progress/package.json
@@ -16,9 +16,6 @@
     },
     "./circular-progress.css": "./circular-progress.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -17,9 +17,6 @@
     },
     "./data-table.css": "./data-table.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/elevation/package.json
+++ b/packages/elevation/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/floating-label/package.json
+++ b/packages/floating-label/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -15,9 +15,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/grid-list/package.json
+++ b/packages/grid-list/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -15,9 +15,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -17,9 +17,6 @@
     },
     "./icon.css": "./icon.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/image-list/package.json
+++ b/packages/image-list/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/line-ripple/package.json
+++ b/packages/line-ripple/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -15,9 +15,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -22,9 +22,6 @@
     "./collapsible-list.css": "./collapsible-list.css",
     "./list-item.css": "./list-item.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rc-tooltip/package.json
+++ b/packages/rc-tooltip/package.json
@@ -17,9 +17,6 @@
     },
     "./rc-tooltip.css": "./rc-tooltip.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -17,9 +17,6 @@
     },
     "./ripple.css": "./ripple.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/segmented-button/package.json
+++ b/packages/segmented-button/package.json
@@ -15,9 +15,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -17,9 +17,6 @@
     },
     "./select.css": "./select.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -17,9 +17,6 @@
     },
     "./snackbar.css": "./snackbar.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -15,9 +15,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -15,9 +15,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -17,9 +17,6 @@
     },
     "./textfield.css": "./textfield.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,9 +17,6 @@
     },
     "./theme.css": "./theme.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toggleable/package.json
+++ b/packages/toggleable/package.json
@@ -11,9 +11,6 @@
       "require": "./index.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -16,9 +16,6 @@
     },
     "./tooltip.css": "./tooltip.css"
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -16,9 +16,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/touch-target/package.json
+++ b/packages/touch-target/package.json
@@ -15,9 +15,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -15,9 +15,6 @@
       "require": "./styles.js"
     }
   },
-  "sideEffects": [
-    "**/*.css"
-  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Projects that use vite seems to treeshake styling from RMWC. This PR is a potential fix. I will revert if it does not work.

Some history in regards to why sideEffects was added: https://github.com/rmwc/rmwc/issues/545