### PR TITLE
fix(ripple): have ripple adhere to provider

### DIFF
--- a/packages/icon-button/src/lib/icon-button.spec.tsx
+++ b/packages/icon-button/src/lib/icon-button.spec.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { IconButton } from './icon-button';
+import { RMWCProvider } from '@rmwc/provider';
 
 describe('', () => {
   it('renders with icon as string', () => {
@@ -64,5 +65,25 @@ describe('', () => {
       <IconButton icon="star" className={'my-custom-classname'} />
     );
     expect(container.firstChild).toHaveClass('my-custom-classname');
+  });
+
+  it('adheres to ripple from provider', () => {
+    const { rerender } = render(
+      <RMWCProvider ripple={true}>
+        <IconButton icon="star" label="Rate this!" />
+      </RMWCProvider>
+    );
+    expect(screen.getByRole('button')).toHaveClass(
+      'mdc-ripple-upgraded--unbounded'
+    );
+
+    rerender(
+      <RMWCProvider ripple={false}>
+        <IconButton icon="star" label="Rate this!" />
+      </RMWCProvider>
+    );
+    expect(screen.getByRole('button')).not.toHaveClass(
+      'mdc-ripple-upgraded--unbounded'
+    );
   });
 });

--- a/packages/ripple/src/lib/ripple.spec.tsx
+++ b/packages/ripple/src/lib/ripple.spec.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { Ripple } from './ripple';
+import { RMWCProvider } from '@rmwc/provider';
 
 describe('Ripple', () => {
   it('renders', () => {
@@ -54,5 +55,38 @@ describe('Ripple', () => {
       </Ripple>
     );
     expect(container.firstChild).toHaveClass('mdc-ripple-upgraded--unbounded');
+  });
+
+  it('matches snapshot for ripple set to false', () => {
+    const { asFragment } = render(
+      <RMWCProvider ripple={false}>
+        <Ripple unbounded>
+          <div />
+        </Ripple>
+      </RMWCProvider>
+    );
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <div />
+      </DocumentFragment>
+    `);
+  });
+
+  it('matches snapshot for ripple set to true', () => {
+    const { asFragment } = render(
+      <RMWCProvider ripple={true}>
+        <Ripple unbounded>
+          <div />
+        </Ripple>
+      </RMWCProvider>
+    );
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <div
+          class="mdc-ripple-upgraded--unbounded mdc-ripple-surface"
+          data-mdc-ripple-is-unbounded="true"
+        />
+      </DocumentFragment>
+    `);
   });
 });

--- a/packages/ripple/src/lib/ripple.tsx
+++ b/packages/ripple/src/lib/ripple.tsx
@@ -44,7 +44,13 @@ export function Ripple(props: RippleProps & RMWC.HTMLProps) {
 
   const { rootEl, surfaceEl } = useRippleFoundation(props);
 
+  const providerContext = useProviderContext();
+
   const child = React.Children.only(children);
+
+  if (!providerContext.ripple) {
+    return child;
+  }
 
   if (!React.isValidElement<React.HTMLProps<any>>(child)) {
     return null;


### PR DESCRIPTION
If one uses the `<Ripple />` component directly in their code, it will not adhere to ripple being set to false by the provider `<RMWCProvider ripple={false} />`. This PR is fixing this, so that `<Ripple />` will adhere to the provider.