### PR TITLE
fix(select): fix 'ref will fail' error

### DIFF
--- a/packages/base/src/lib/base.story.tsx
+++ b/packages/base/src/lib/base.story.tsx
@@ -11,7 +11,9 @@ type Story = StoryObj<typeof ListItem>;
 
 export const BaseStory: Story = {
   render: (args) => {
-    const Link = ({ to, ...rest }) => <a href="#" {...rest} />;
+    const Link = React.forwardRef(({ to, ...rest }, ref) => (
+      <a href="#" {...rest} ref={ref} />
+    ));
     return (
       <ListItem tag={Link} {...args}>
         <ListItemGraphic icon="home" />

--- a/packages/select/src/lib/select/index.tsx
+++ b/packages/select/src/lib/select/index.tsx
@@ -194,9 +194,11 @@ function NativeMenu(
   );
 }
 
-const AnchorEl = withRipple({ surface: false })(function (props: any) {
-  return <Tag {...props} />;
-});
+const AnchorEl = withRipple({ surface: false })(
+  React.forwardRef(function (props: any, ref: any) {
+    return <Tag {...props} ref={ref} />;
+  })
+);
 
 interface EnhancedMenuProps extends MenuProps {
   selectOptions: FormattedOption[];


### PR DESCRIPTION
# Motivation
Fixes #1327

# Problem
Using `Select` results in the following runtime error:
```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
```

# PR changes
Pass a ref-forwarding component as child to `withRipple`.

The same error message is caused similarly by the `BaseStory` story, so I fixed it here as well.

I am unsure whether this can/should be tested.