### PR TITLE
fix(linear-progress): prevent fast-unmount error

### DIFF
--- a/packages/linear-progress/src/lib/foundation.tsx
+++ b/packages/linear-progress/src/lib/foundation.tsx
@@ -54,7 +54,9 @@ export const useLinearProgressFoundation = (props: LinearProgressProps) => {
           const RO = (window as unknown as WithMDCResizeObserver)
             .ResizeObserver;
           if (RO) {
-            const ro = new RO(callback);
+            const ro = new RO(
+              (entries, observer) => rootEl.ref && callback(entries, observer)
+            );
             ro.observe(rootEl.ref as Element);
             return ro;
           }


### PR DESCRIPTION
# Problem

When mounting and immediately unmounting an indeterminate `LinearProgress`, sometimes the following error is thrown:
```
Uncaught TypeError: Cannot read properties of null (reading 'style')
    at Object.setStyle (index.mjs:41:1)
    at MDCLinearProgressFoundation.calculateAndSetDimensions (foundation.js:193:1)
    at ResizeObserver.eval (foundation.js:82:1)
```

# Cause

Upon mounting, a resize observer is attached. This observer always triggers once after setup (expected behaviour of resize observers). With just the right timing, the callback is executed when the component has already been unmounted again.

# Solution

Prevent the callback from being executed altogether if the element is not in the dom anymore.

Since this is a race condition, I wasn't able to reliably reproduce it and therefore added no tests.