### PR TITLE
docs: update css import lists

### DIFF
--- a/utils/readme/src/readmes/avatar.tsx
+++ b/utils/readme/src/readmes/avatar.tsx
@@ -24,6 +24,7 @@ export default function Readme() {
       styles={[
         '@rmwc/avatar/avatar.css',
         '@rmwc/icon/icon.css',
+        '@rmwc/ripple/ripple.css',
         '@material/ripple/dist/mdc.ripple.css'
       ]}
       examples={examples}

--- a/utils/readme/src/readmes/button.tsx
+++ b/utils/readme/src/readmes/button.tsx
@@ -16,7 +16,8 @@ export default function Readme() {
       module="@rmwc/button"
       styles={[
         '@material/button/dist/mdc.button.css',
-        '@rmwc/@rmwc/icon/icon.css',
+        '@rmwc/icon/icon.css',
+        '@rmwc/ripple/ripple.css',
         '@material/ripple/dist/mdc.ripple.css'
       ]}
       docsLink="https://material.io/develop/web/components/buttons/"

--- a/utils/readme/src/readmes/card.tsx
+++ b/utils/readme/src/readmes/card.tsx
@@ -28,6 +28,9 @@ export default function Readme() {
       styles={[
         '@material/card/dist/mdc.card.css',
         '@material/button/dist/mdc.button.css',
+        '@rmwc/icon/icon.css',
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css',
         '@material/icon-button/dist/mdc.icon-button.css'
       ]}
       docsLink="https://material.io/develop/web/components/cards/"

--- a/utils/readme/src/readmes/checkbox.tsx
+++ b/utils/readme/src/readmes/checkbox.tsx
@@ -15,7 +15,8 @@ export default function Readme() {
       styles={[
         '@material/checkbox/dist/mdc.checkbox.css',
         '@material/form-field/dist/mdc.form-field.css',
-        '@material/ripple/dist/mdc.ripple.css'
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css'
       ]}
       docsLink="https://material.io/develop/web/components/input-controls/checkboxes/"
       examples={examples}

--- a/utils/readme/src/readmes/chip.tsx
+++ b/utils/readme/src/readmes/chip.tsx
@@ -20,8 +20,11 @@ export default function Readme() {
       module="@rmwc/chip"
       styles={[
         '@material/chips/dist/mdc.chips.css',
+        '@material/chips/styles.scss',
         '@rmwc/icon/icon.css',
-        '@material/ripple/dist/mdc.ripple.css'
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css',
+        '@rmwc/chip/chip.css'
       ]}
       docsLink="https://material.io/develop/web/components/chips/"
       examples={examples}

--- a/utils/readme/src/readmes/circular-progress.tsx
+++ b/utils/readme/src/readmes/circular-progress.tsx
@@ -16,7 +16,10 @@ export default function Readme() {
       title="Circular Progress"
       lead="Circular progress indicators display progress by animating an indicator along an invisible circular track in a clockwise direction. They can be applied directly to a surface, such as a button or card."
       module="@rmwc/circular-progress"
-      styles={['@rmwc/circular-progress/circular-progress.css']}
+      styles={[
+        '@material/circular-progress/dist/mdc.circular-progress.css',
+        '@rmwc/circular-progress/circular-progress.css'
+      ]}
       examples={examples}
     >
       <DocsSubtitle>Basic Usage</DocsSubtitle>

--- a/utils/readme/src/readmes/dialog.tsx
+++ b/utils/readme/src/readmes/dialog.tsx
@@ -32,6 +32,8 @@ export default function Readme() {
       styles={[
         '@material/dialog/dist/mdc.dialog.css',
         '@material/button/dist/mdc.button.css',
+        '@rmwc/icon/icon.css',
+        '@rmwc/ripple/ripple.css',
         '@material/ripple/dist/mdc.ripple.css'
       ]}
       docsLink="https://material.io/develop/web/components/dialogs/"

--- a/utils/readme/src/readmes/fab.tsx
+++ b/utils/readme/src/readmes/fab.tsx
@@ -15,7 +15,8 @@ export default function Readme() {
       styles={[
         '@material/fab/dist/mdc.fab.css',
         '@rmwc/icon/icon.css',
-        '@material/ripple/dist/mdc.ripple.css'
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css'
       ]}
       docsLink="https://material.io/develop/web/components/buttons/floating-action-buttons/"
       examples={examples}

--- a/utils/readme/src/readmes/icon-button.tsx
+++ b/utils/readme/src/readmes/icon-button.tsx
@@ -21,7 +21,8 @@ export default function Readme() {
       styles={[
         '@material/icon-button/dist/mdc.icon-button.css',
         '@rmwc/icon/icon.css',
-        '@material/ripple/dist/mdc.ripple.css'
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css'
       ]}
       docsLink="https://material.io/develop/web/components/buttons/icon-buttons/"
       examples={examples}

--- a/utils/readme/src/readmes/list-collapsible.tsx
+++ b/utils/readme/src/readmes/list-collapsible.tsx
@@ -21,7 +21,11 @@ export default function Readme() {
       module="@rmwc/list"
       styles={[
         '@material/list/dist/mdc.list.css',
-        '@rmwc/list/collapsible-list.css'
+        '@rmwc/icon/icon.css',
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css',
+        '@rmwc/list/collapsible-list.css',
+        '@rmwc/list/list-item.css'
       ]}
       examples={examples}
       addon

--- a/utils/readme/src/readmes/list-variants.tsx
+++ b/utils/readme/src/readmes/list-variants.tsx
@@ -35,7 +35,14 @@ export default function Readme() {
       title="Lists"
       lead="Lists are continuous, vertical indexes of text or images."
       module="@rmwc/list"
-      styles={['@material/list/dist/mdc.list.css']}
+      styles={[
+        '@material/list/dist/mdc.list.css',
+        '@rmwc/icon/icon.css',
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css',
+        '@rmwc/list/collapsible-list.css',
+        '@rmwc/list/list-item.css'
+      ]}
       docsLink="https://material.io/develop/web/components/lists/"
       examples={examples}
     >

--- a/utils/readme/src/readmes/list.tsx
+++ b/utils/readme/src/readmes/list.tsx
@@ -32,8 +32,11 @@ export default function Readme() {
       module="@rmwc/list"
       styles={[
         '@material/list/dist/mdc.list.css',
+        '@rmwc/icon/icon.css',
         '@material/ripple/dist/mdc.ripple.css',
-        '@rmwc/icon/icon.css'
+        '@rmwc/ripple/ripple.css',
+        '@rmwc/list/collapsible-list.css',
+        '@rmwc/list/list-item.css'
       ]}
       docsLink="https://material.io/develop/web/components/lists/"
       examples={examples}

--- a/utils/readme/src/readmes/menu.tsx
+++ b/utils/readme/src/readmes/menu.tsx
@@ -34,9 +34,13 @@ export default function Readme() {
       styles={[
         '@material/menu/dist/mdc.menu.css',
         '@material/menu-surface/dist/mdc.menu-surface.css',
-        '@material/ripple/dist/mdc.ripple.css',
+
         '@material/list/dist/mdc.list.css',
-        '@rmwc/icon/icon.css'
+        '@rmwc/icon/icon.css',
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css',
+        '@rmwc/list/collapsible-list.css',
+        '@rmwc/list/list-item.css'
       ]}
       docsLink="https://material.io/develop/web/components/menus/"
       examples={examples}

--- a/utils/readme/src/readmes/radio.tsx
+++ b/utils/readme/src/readmes/radio.tsx
@@ -21,7 +21,8 @@ export default function Readme() {
       styles={[
         '@material/radio/dist/mdc.radio.css',
         '@material/form-field/dist/mdc.form-field.css',
-        '@material/ripple/dist/mdc.ripple.css'
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css'
       ]}
       docsLink="https://material.io/develop/web/components/input-controls/radio-buttons/"
       examples={examples}

--- a/utils/readme/src/readmes/ripple.tsx
+++ b/utils/readme/src/readmes/ripple.tsx
@@ -13,7 +13,10 @@ export default function Readme() {
       title="Ripples"
       lead="MDC Ripple provides the JavaScript and CSS required to provide components (or any element at all) with a material “ink ripple” interaction effect. It is designed to be efficient, uninvasive, and usable without adding any extra DOM to your elements."
       module="@rmwc/ripple"
-      styles={['@material/ripple/dist/mdc.ripple.css']}
+      styles={[
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css'
+      ]}
       docsLink="https://material.io/develop/web/components/ripples/"
       examples={examples}
     >

--- a/utils/readme/src/readmes/segmented-button.tsx
+++ b/utils/readme/src/readmes/segmented-button.tsx
@@ -16,8 +16,9 @@ export default function Readme() {
       module="@rmwc/segmented-button"
       styles={[
         '@material/segmented-button/dist/mdc.segmented-button.css',
-        '@rmwc/@rmwc/icon/icon.css',
-        '@material/ripple/dist/mdc.ripple.css'
+        '@rmwc/icon/icon.css',
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css'
       ]}
       docsLink="https://material.io/develop/web/components/segmented-button/"
       examples={examples}

--- a/utils/readme/src/readmes/select.tsx
+++ b/utils/readme/src/readmes/select.tsx
@@ -21,15 +21,34 @@ export default function Readme() {
       lead="Menus display a list of choices on a transient sheet of material."
       module="@rmwc/select"
       styles={[
-        '@rmwc/select/select.css',
         '@material/select/dist/mdc.select.css',
+
         '@material/floating-label/dist/mdc.floating-label.css',
-        '@material/notched-outline/dist/mdc.notched-outline.css',
+
         '@material/line-ripple/dist/mdc.line-ripple.css',
+
         '@material/list/dist/mdc.list.css',
+        '@rmwc/icon/icon.css',
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css',
+        '@rmwc/list/collapsible-list.css',
+        '@rmwc/list/list-item.css',
+
         '@material/menu/dist/mdc.menu.css',
         '@material/menu-surface/dist/mdc.menu-surface.css',
-        '@material/ripple/dist/mdc.ripple.css'
+        // '@material/list/dist/mdc.list.css',
+        // '@rmwc/icon/icon.css',
+        // '@material/ripple/dist/mdc.ripple.css',
+        // '@rmwc/ripple/ripple.css',
+        // '@rmwc/list/collapsible-list.css',
+        // '@rmwc/list/list-item.css',
+
+        '@material/notched-outline/dist/mdc.notched-outline.css',
+
+        // '@material/ripple/dist/mdc.ripple.css',
+        // '@rmwc/ripple/ripple.css',
+
+        '@rmwc/select/select.css'
       ]}
       docsLink="https://material.io/develop/web/components/input-controls/select-menus/"
       examples={examples}

--- a/utils/readme/src/readmes/snackbar.tsx
+++ b/utils/readme/src/readmes/snackbar.tsx
@@ -27,7 +27,8 @@ export default function Readme() {
       styles={[
         '@material/snackbar/dist/mdc.snackbar.css',
         '@material/button/dist/mdc.button.css',
-        '@material/ripple/dist/mdc.ripple.css'
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/snackbar/snackbar.css'
       ]}
       docsLink="https://material.io/develop/web/components/snackbars/"
       examples={examples}

--- a/utils/readme/src/readmes/switch.tsx
+++ b/utils/readme/src/readmes/switch.tsx
@@ -15,7 +15,8 @@ export default function Readme() {
       styles={[
         '@material/switch/dist/mdc.switch.css',
         '@material/form-field/dist/mdc.form-field.css',
-        '@material/ripple/dist/mdc.ripple.css'
+        '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css'
       ]}
       docsLink="https://material.io/develop/web/components/input-controls/switches/"
       examples={examples}

--- a/utils/readme/src/readmes/tabs.tsx
+++ b/utils/readme/src/readmes/tabs.tsx
@@ -24,6 +24,7 @@ export default function Readme() {
         '@material/tab-scroller/dist/mdc.tab-scroller.css',
         '@material/tab-indicator/dist/mdc.tab-indicator.css',
         '@material/ripple/dist/mdc.ripple.css',
+        '@rmwc/ripple/ripple.css',
         '@rmwc/icon/icon.css'
       ]}
       docsLink="https://material.io/develop/web/components/tabs/tab-bar/"

--- a/utils/readme/src/readmes/textfield.tsx
+++ b/utils/readme/src/readmes/textfield.tsx
@@ -21,10 +21,12 @@ export default function Readme() {
       styles={[
         '@material/textfield/dist/mdc.textfield.css',
         '@material/floating-label/dist/mdc.floating-label.css',
-        '@material/notched-outline/dist/mdc.notched-outline.css',
+        '@rmwc/icon/icon.css',
         '@material/line-ripple/dist/mdc.line-ripple.css',
+        '@material/notched-outline/dist/mdc.notched-outline.css',
         '@material/ripple/dist/mdc.ripple.css',
-        '@rmwc/icon/icon.css'
+        '@rmwc/ripple/ripple.css',
+        '@rmwc/textfield/textfield.css'
       ]}
       docsLink="https://material.io/develop/web/components/input-controls/text-field/"
       examples={examples}

--- a/utils/readme/src/readmes/top-app-bar.tsx
+++ b/utils/readme/src/readmes/top-app-bar.tsx
@@ -29,9 +29,16 @@ export default function Readme() {
       module="@rmwc/top-app-bar"
       styles={[
         '@material/top-app-bar/dist/mdc.top-app-bar.css',
+
         '@material/icon-button/dist/mdc.icon-button.css',
+        '@rmwc/icon/icon.css',
         '@material/ripple/dist/mdc.ripple.css',
-        '@rmwc/icon/icon.css'
+        '@rmwc/ripple/ripple.css'
+
+        // '@rmwc/icon/icon.css',
+
+        // '@material/ripple/dist/mdc.ripple.css',
+        // '@rmwc/ripple/ripple.css',
       ]}
       docsLink="https://material.io/develop/web/components/top-app-bar/"
       examples={examples}

--- a/utils/readme/src/readmes/touch-target.tsx
+++ b/utils/readme/src/readmes/touch-target.tsx
@@ -13,7 +13,7 @@ export default function Readme() {
       title="Touch Target"
       lead="Touch targets are the parts of the screen that respond to user input. They extend beyond the visual bounds of an element. For example, an icon may appear to be 24 x 24 dp, but the padding surrounding it comprises the full 48 x 48 dp touch target."
       module="@rmwc/touch-target-wrapper"
-      styles={['@material/button/dist/mdc.button.css']}
+      styles={['@material/touch-target/styles.scss']}
       docsLink="https://material.io/design/usability/accessibility.html#understanding-accessibility"
       examples={examples}
     >


### PR DESCRIPTION
# Problem

I had broken styles after updating from an old version.

# Cause

Because I'm using next.js, I have to manually import the stylesheets listed in the documentation. These are outdated.

# Solution

I went through all rmwc packages by hand and assured that all files imported by `packages/<package>/src/styles.ts` are mentioned in the documentation.

I was a little unsure what to do with `list-collapsible`. The component itself is located within the `list` directory. There exists `collapsible-list.ts` and `styles.ts` containing style imports. However,
- `collapsible-list.ts` is a subset of `styles.ts`,
- `styles.ts` imports `collapsible-list.ts`,
- none of the three list docs pages mentions `collapsible-list.ts`.
I decided to reflect `styles.ts` as in the other list pages, but you should take a look at this one.

In a personal project I wasn't able to import '@rmwc/list/list-item.css from the list component, so this probably needs correction. (After further investigation it seems these styles end up in `styles.css`, I just don't know why).

In the snackbar component it reads:
```ts
import '@material/button/dist/mdc.button.css';
import '@material/ripple/dist/mdc.ripple.css';
```
while in all other components the following is used:
```ts
import '@rmwc/button/styles';
import '@rmwc/ripple/styles';
```
I decided to leave this change up to you. But if adapted, the docs need to be updated accordingly.

There is a docs page `touch-target.tsx` that I was unable to find in the web interface. I still adapted it to reflect the components `styles.ts`.

## Further discussion

Doing this manually took quite some time. Ideally, it would be possible to express the dependencies in a way that docs and code would be generated from it. This would prevent them becoming out of sync, although I don't know if/how this is possible.

Even if it can't be autogenerated, a notice in `CONTRIBUTING.md` might be added to draw the attention to the fact the docs must be updated when css imports are changed. I would even consider this type of change breaking(!) and mark it as such, since it requires code changes by the user.