### PR TITLE
fix(select): correctly set defaultvalue, onchange fire only once, disabled prop passed correctly

### DIFF
--- a/packages/select/src/lib/__snapshots__/select.spec.tsx.snap
+++ b/packages/select/src/lib/__snapshots__/select.spec.tsx.snap
@@ -318,7 +318,7 @@ exports[`Select: Lifecycle > Select matches snapshot when enhanced, has defaultV
         role="menu"
       >
         <li
-          class="mdc-deprecated-list-item"
+          class="mdc-deprecated-list-item mdc-deprecated-list-item--activated"
           data-value="Cookies"
           role="menuitem"
           tabindex="0"

--- a/packages/select/src/lib/select.spec.tsx
+++ b/packages/select/src/lib/select.spec.tsx
@@ -31,16 +31,6 @@ const ConditionallyRenderedSelect = ({
   );
 };
 
-test('renders learn react link', async () => {
-  const onChange = vi.fn();
-  render(
-    <Select label="myLabel" onChange={onChange} options={['cookie', 'pizza']} />
-  );
-
-  await userEvent.selectOptions(screen.getByRole('combobox'), 'pizza');
-  expect(onChange).toHaveBeenCalled();
-});
-
 describe('Select', () => {
   it('renders', () => {
     const { asFragment } = render(
@@ -51,6 +41,41 @@ describe('Select', () => {
       />
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('calls onChange', async () => {
+    const onChange = vi.fn();
+    render(
+      <Select
+        label="myLabel"
+        onChange={onChange}
+        options={['cookie', 'pizza']}
+      />
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'pizza');
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  test('calls onChange enhanced', async () => {
+    const onChange = vi.fn();
+    render(
+      <Select
+        label="myLabel"
+        onChange={onChange}
+        options={['cookie', 'pizza']}
+        enhanced
+      />
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('menuitem', { name: 'pizza' }));
+
+    expect(onChange).toHaveBeenCalled();
   });
 
   it('helpText', () => {

--- a/packages/select/src/lib/select.spec.tsx
+++ b/packages/select/src/lib/select.spec.tsx
@@ -43,7 +43,7 @@ describe('Select', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('calls onChange', async () => {
+  it('calls onChange', async () => {
     const onChange = vi.fn();
     render(
       <Select
@@ -60,7 +60,7 @@ describe('Select', () => {
     expect(onChange).toHaveBeenCalled();
   });
 
-  test('calls onChange enhanced', async () => {
+  it('calls onChange enhanced', async () => {
     const onChange = vi.fn();
     render(
       <Select
@@ -206,14 +206,18 @@ describe('Select', () => {
 
   it('can be disabled', () => {
     const selectInput = render(
-      <Select disabled={false} options={['1', '2', '3']} />
+      <Select label="myLabel" disabled={false} options={['1', '2', '3']} />
     );
+
+    expect(screen.getByRole('combobox')).not.toBeDisabled();
 
     expect(
       selectInput.container.getElementsByClassName('mdc-select--disabled')
     ).toHaveLength(0);
 
     selectInput.rerender(<Select disabled={true} options={['1', '2', '3']} />);
+
+    expect(screen.getByRole('combobox')).toBeDisabled();
 
     expect(
       selectInput.container.getElementsByClassName('mdc-select--disabled')

--- a/packages/select/src/lib/select.spec.tsx
+++ b/packages/select/src/lib/select.spec.tsx
@@ -222,6 +222,10 @@ describe('Select', () => {
       screen.getByTestId('display-selection'),
       'Icecream'
     );
+    await userEvent.selectOptions(
+      screen.getByTestId('display-selection'),
+      'Icecream'
+    );
 
     await userEvent.click(screen.getByText(/next/i));
     await userEvent.selectOptions(

--- a/packages/select/src/lib/select.story.tsx
+++ b/packages/select/src/lib/select.story.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Select } from './select'; // replace with your actual component import
 import { Meta, StoryObj } from '@storybook/react';
 import { Portal } from '@rmwc/base';
@@ -300,7 +300,14 @@ function EnhancedSelectWithPortal(props: { value?: string }) {
 export const SelectWithObjectStory: Story = {
   render: (args) => {
     const { label, placeholder, options } = args;
-    return <Select label={label} placeholder={placeholder} options={options} />;
+    return (
+      <Select
+        label={label}
+        placeholder={placeholder}
+        options={options}
+        onChange={() => console.count('select')}
+      />
+    );
   },
   args: {
     label: 'Foods',
@@ -452,4 +459,28 @@ export const ChangingSelectStory: Story = {
 
 export const DependentSelectsStory: Story = {
   render: () => <DependentSelects />
+};
+
+export const ConditionallyRenderedSelect: Story = {
+  render: () => {
+    const [displaySelect, setDisplaySelect] = React.useState('');
+    return (
+      <>
+        <Select
+          data-testid="display-selection"
+          label="Display"
+          onChange={(e) => setDisplaySelect(e.currentTarget.value)}
+          value={displaySelect}
+          options={['cookie', 'pizza', 'Icecream']}
+        />
+        {displaySelect && (
+          <Select
+            data-testid="next-selection"
+            label="Next"
+            options={['cookie', 'pizza']}
+          />
+        )}
+      </>
+    );
+  }
 };

--- a/packages/select/src/lib/select.story.tsx
+++ b/packages/select/src/lib/select.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Select } from './select'; // replace with your actual component import
 import { Meta, StoryObj } from '@storybook/react';
 import { Portal } from '@rmwc/base';
@@ -459,28 +459,4 @@ export const ChangingSelectStory: Story = {
 
 export const DependentSelectsStory: Story = {
   render: () => <DependentSelects />
-};
-
-export const ConditionallyRenderedSelect: Story = {
-  render: () => {
-    const [displaySelect, setDisplaySelect] = React.useState('');
-    return (
-      <>
-        <Select
-          data-testid="display-selection"
-          label="Display"
-          onChange={(e) => setDisplaySelect(e.currentTarget.value)}
-          value={displaySelect}
-          options={['cookie', 'pizza', 'Icecream']}
-        />
-        {displaySelect && (
-          <Select
-            data-testid="next-selection"
-            label="Next"
-            options={['cookie', 'pizza']}
-          />
-        )}
-      </>
-    );
-  }
 };

--- a/packages/select/src/lib/select/foundation.tsx
+++ b/packages/select/src/lib/select/foundation.tsx
@@ -157,7 +157,7 @@ export const useSelectFoundation = (
           notifyChange: (value: any) => {
             if (!silenceChange.current) {
               emit(
-                'onChange',
+                props.enhanced ? 'onChange' : 'MDCSelect:change',
                 {
                   index: selectedIndex.current,
                   value
@@ -442,8 +442,8 @@ export const useSelectFoundation = (
     setNativeControl,
     handleFocus,
     handleBlur,
-    handleClick,
     handleChange,
+    handleClick,
     handleKeydown,
     handleMenuClosed,
     handleMenuOpened,

--- a/packages/select/src/lib/select/foundation.tsx
+++ b/packages/select/src/lib/select/foundation.tsx
@@ -375,6 +375,9 @@ export const useSelectFoundation = (
     ? props.options.length
     : Object.values(props.options || {}).length;
 
+  // @ts-ignore unsafe private variable access
+  const menuItemValues = foundation.menuItemValues;
+
   // MDC Select is a bit of a mess here...
   // - We have to set our value
   // - In the event of a controlled value change, we don't want to fire a change event
@@ -383,14 +386,12 @@ export const useSelectFoundation = (
     silenceChange.current = true;
 
     if (value !== undefined && value !== foundationValue) {
-      // @ts-ignore unsafe private variable access
-      const index = foundation.menuItemValues.indexOf(value);
+      const index = menuItemValues.indexOf(value);
       selectedIndex.current = index;
       foundation.setValue(value || '');
 
       // We need to call setSelectedTextContent to set the default value/the controlled value.
-      // @ts-ignore unsafe private variable access
-      if (foundation.menuItemValues.includes(value)) {
+      if (menuItemValues.includes(value)) {
         // @ts-ignore unsafe private variable access
         const textContent = foundation.adapter.getMenuItemTextAtIndex(index);
         setSelectedTextContent(textContent);
@@ -399,7 +400,7 @@ export const useSelectFoundation = (
     raf(() => {
       silenceChange.current = false;
     });
-  }, [value, foundationValue, optionsLength, foundation]);
+  }, [value, foundationValue, optionsLength, foundation, menuItemValues]);
 
   // Disabled
   useEffect(() => {
@@ -416,6 +417,14 @@ export const useSelectFoundation = (
   useEffect(() => {
     if (defaultValue) {
       setSelectedTextContent(defaultValue.toString());
+    }
+  }, []);
+
+  // open
+  useEffect(() => {
+    if (props.open) {
+      setMenuOpen(true);
+      foundation.handleMenuOpened();
     }
   }, []);
 

--- a/packages/select/src/lib/select/index.tsx
+++ b/packages/select/src/lib/select/index.tsx
@@ -366,8 +366,8 @@ export const Select: RMWC.ComponentType<
     setMenu,
     handleFocus,
     handleBlur,
-    handleClick,
     handleChange,
+    handleClick,
     handleKeydown,
     handleMenuClosed,
     handleMenuOpened,
@@ -436,7 +436,6 @@ export const Select: RMWC.ComponentType<
           onBlur={handleBlur}
           onClick={handleClick}
           onKeyDown={handleKeydown}
-          onChange={handleChange}
           /** In the case of native selects, we don't want this to be be focusable */
           tabIndex={enhanced ? undefined : -1}
         >
@@ -474,6 +473,7 @@ export const Select: RMWC.ComponentType<
                 handleMenuClosed();
               }}
               onChange={(evt: React.ChangeEvent<HTMLSelectElement>) => {
+                handleChange(evt);
                 handleMenuSelected(evt.currentTarget.selectedIndex);
               }}
             />

--- a/packages/select/src/lib/select/index.tsx
+++ b/packages/select/src/lib/select/index.tsx
@@ -476,6 +476,7 @@ export const Select: RMWC.ComponentType<
                 handleChange(evt);
                 handleMenuSelected(evt.currentTarget.selectedIndex);
               }}
+              disabled={disabled}
             />
           )}
         </AnchorEl>
@@ -487,6 +488,7 @@ export const Select: RMWC.ComponentType<
             ref={ref}
             anchorCorner={enhancedMenuProps.anchorCorner ?? 'bottomStart'}
             defaultValue={defaultValue}
+            disabled={disabled}
             placeholder={placeholder}
             open={menuOpen}
             onClose={handleMenuClosed}


### PR DESCRIPTION
This PR fixes three issues:

- When setting default value, the select would display the value and not the label. Now the correct text is set.
- onChange event would fire three times. Now it fires once.
- disabled prop was not passed correctly. It is now.