### PR TITLE
fix(Select): Disable select issue for onFocus getting false instead of function

### DIFF
--- a/packages/select/src/lib/select/index.tsx
+++ b/packages/select/src/lib/select/index.tsx
@@ -432,7 +432,7 @@ export const Select: RMWC.ComponentType<
           aria-haspopup="listbox"
           aria-labelledby={labelId}
           element={anchorEl}
-          onFocus={!disabled && handleFocus}
+          onFocus={!disabled ? handleFocus : undefined}
           onBlur={handleBlur}
           onClick={handleClick}
           onKeyDown={handleKeydown}


### PR DESCRIPTION
While select is disabled, there is an error:
app-index.js:33 Warning: Expected onFocus listener to be a function, instead got false.

## Screenshot:
![Screenshot 2024-10-03 12 45 42 PM](https://github.com/user-attachments/assets/5aa14d21-e0d0-4ac2-9304-886650543741)
